### PR TITLE
Add the extension higher up the chain

### DIFF
--- a/_config.php
+++ b/_config.php
@@ -1,6 +1,6 @@
 <?php
-// Add custom menu controller to ContentController
-ContentController::add_extension('CustomMenu');
+// Add custom menu controller to Controller
+Controller::add_extension('CustomMenu');
 SiteTree::add_extension('CustomMenuExtension');
 LeftAndMain::add_extension('CustomMenu_LeftAndMain');
 

--- a/code/extensions/CustomMenu.php
+++ b/code/extensions/CustomMenu.php
@@ -2,6 +2,14 @@
 class CustomMenu extends Extension {
 
     /**
+     * Define constructor otherwise PHP will fall back to calling the function
+     * named after the class which throws an error on inital setup
+     */
+    function __construct() {
+        parent::__construct();
+    }
+
+    /**
      * Generate an list of items that will be loaded into the custom menu
      *
      * @param $menu template slug for retriving a menu


### PR DESCRIPTION
Currently if you create a controller which just extends Controller (eg http://doc.silverstripe.org/framework/en/topics/controller) then you don't get access to the CustomMenus which have been setup. 

Moving where the extension is applied allows it to work on the custom controllers along with the other types as normal.